### PR TITLE
Update formplayer staging to track commcare-core master

### DIFF
--- a/formplayer-staging.yml
+++ b/formplayer-staging.yml
@@ -2,10 +2,8 @@
 
 trunk: master
 name: autostaging
-branches:
-  - dmr/add-getBulkIdsForIndex-to-SqlStorage  # Danny Mar 18, 2026
+branches: []
 submodules:
   libs/commcare:
-    trunk: formplayer
-    branches:
-      - masterToFormplayer2.60  # goes with dmr/add-getBulkIdsForIndex-to-SqlStorage
+    trunk: master
+    branches: []


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SAAS-19426

Note: this PR affects only **formplayer-staging.yml** which we normally just push straight to master. However, I'm raising this as a PR for visibility, since it's embedding something that's conceptually more of a structural change (tracking master branch as trunk) rather than just changing what other branches we want on staging right now.

## Summary

The commcare-core `formplayer` branch has been eliminated. This updates `formplayer-staging.yml` so the `libs/commcare` submodule tracks `master` instead of the now-deleted `formplayer` branch.

## Changes

- Changed `libs/commcare` trunk from `formplayer` to `master`
- Removed merged branch entries:
  - `dmr/add-getBulkIdsForIndex-to-SqlStorage` (feature branch deleted from remote)
  - `masterToFormplayer2.60` (already merged into commcare-core master)

## Context

This is part of the formplayer branch elimination effort. Both commcare-android and formplayer now consume commcare-core's `master` branch directly. See [commcare-core PR #1525](https://github.com/dimagi/commcare-core/pull/1525) for the cross-repo CI setup.

## Test plan

- [ ] Verify `./scripts/rebuildstaging` in the formplayer repo succeeds with this config