### PR TITLE
Document push-based rebuild trigger in commcare-hq

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ The general workflow is virtually the same across repositories. The convention i
 
 ## Automated Staging Rebuild
 
-When `commcare-hq-staging.yml` is pushed to `main`, a GitHub Actions workflow automatically triggers the [`rebuild-staging`](https://github.com/dimagi/commcare-hq/actions/workflows/rebuild-staging.yml) workflow in `dimagi/commcare-hq`. This removes the need to manually run `./scripts/rebuildstaging` after updating the branch list.
+The `autostaging` branch is rebuilt automatically in two ways:
 
-You can monitor the triggered run in the [commcare-hq Actions tab](https://github.com/dimagi/commcare-hq/actions/workflows/rebuild-staging.yml).
+1. **Config changes:** When `commcare-hq-staging.yml` is pushed to `main` in this repo, a workflow here triggers [`rebuild-staging`](https://github.com/dimagi/commcare-hq/actions/workflows/rebuild-staging.yml) in `dimagi/commcare-hq` via `workflow_dispatch`.
+2. **Branch pushes:** The `rebuild-staging` workflow in `dimagi/commcare-hq` also runs on push to any branch. It checks this config file and skips the rebuild if the pushed branch isn't listed. This means pushes to `master` or to any branch already in the config will trigger a rebuild automatically.
+
+The only case where `autostaging` can go stale is when new commits are pushed to a branch declared in a submodule's staging config.
+
+You can monitor triggered runs in the [commcare-hq Actions tab](https://github.com/dimagi/commcare-hq/actions/workflows/rebuild-staging.yml).
 
 For implementation details, maintenance, and how to extend this to other repos, see [docs/automated-rebuild-trigger.md](docs/automated-rebuild-trigger.md).
 

--- a/docs/automated-rebuild-trigger.md
+++ b/docs/automated-rebuild-trigger.md
@@ -4,7 +4,10 @@ This document covers how the automated staging rebuild trigger works and how to 
 
 ## Overview
 
-The workflow at `.github/workflows/trigger-commcare-hq-rebuild.yml` fires on pushes to `main` that modify `commcare-hq-staging.yml`. It triggers `rebuild-staging` in `dimagi/commcare-hq` via `workflow_dispatch`.
+There are two triggers that keep `autostaging` up to date:
+
+1. **This repo** — `.github/workflows/trigger-commcare-hq-rebuild.yml` fires on pushes to `main` that modify `commcare-hq-staging.yml`. It triggers `rebuild-staging` in `dimagi/commcare-hq` via `workflow_dispatch`.
+2. **commcare-hq** — The [`rebuild-staging` workflow](https://github.com/dimagi/commcare-hq/blob/master/.github/workflows/rebuild-staging.yml) fires on push to any branch. A `check-branch` job fetches `commcare-hq-staging.yml` and skips the rebuild if the pushed branch isn't listed. This covers pushes to `master` (the base branch) and pushes to branches already in the config. A global concurrency group with `cancel-in-progress: false` ensures at most one rebuild runs at a time, with one queued.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Updates docs to reflect that the `rebuild-staging` workflow in commcare-hq now also triggers on branch pushes (dimagi/commcare-hq#37583), not just `workflow_dispatch`.

- **README.md**: Rewrites "Automated Staging Rebuild" section to describe both trigger paths and the remaining edge case (submodule branches)
- **docs/automated-rebuild-trigger.md**: Adds the commcare-hq push trigger to the Overview section

🤖 Generated with [Claude Code](https://claude.com/claude-code)