### PR TITLE
Add workflow to auto-remove merged branches from staging config

### DIFF
--- a/.github/workflows/remove-branch.yml
+++ b/.github/workflows/remove-branch.yml
@@ -29,19 +29,30 @@ jobs:
             exit 1
           fi
 
-          # Remove standalone branch entry (not +-joined conflict resolution branches).
-          # Matches lines like "    - branch-name  # optional comment"
-          # but not "    - foo+branch-name+bar"
-          grep -vP "^\s*-\s+\Q${BRANCH}\E(\s|$)" "$FILE" > "${FILE}.tmp" || true
-          mv "${FILE}.tmp" "$FILE"
-
-          if git diff --quiet -- "$FILE"; then
-            echo "::notice::Branch '$BRANCH' not found in $FILE, nothing to remove"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Removed branch '$BRANCH' from $FILE"
-            git diff -- "$FILE"
+          # Verify branch is in .branches (not submodules or elsewhere).
+          # This scopes the removal to the main branches list and excludes
+          # +-joined conflict resolution branches (those aren't equal strings).
+          match_count=$(yq '[.branches[] | select(. == env(BRANCH))] | length' "$FILE")
+          if [ "$match_count" = "0" ]; then
+            echo "::notice::Branch '$BRANCH' not in .branches of $FILE, nothing to remove"
+            exit 0
           fi
+
+          # Delete only the first line matching the branch as a standalone entry.
+          # Since .branches comes before submodules in the file, this correctly
+          # targets the branches section even if a submodule happens to list
+          # a branch with the same name.
+          line_num=$(grep -nP "^\s*-\s+\Q${BRANCH}\E(\s|$)" "$FILE" | head -1 | cut -d: -f1)
+          if [ -z "$line_num" ]; then
+            echo "::error::Branch verified in .branches but grep couldn't locate the line"
+            exit 1
+          fi
+
+          sed -i "${line_num}d" "$FILE"
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "Removed branch '$BRANCH' from $FILE (line $line_num)"
+          git diff -- "$FILE"
 
       - name: Commit and push
         if: steps.remove.outputs.changed == 'true'

--- a/.github/workflows/remove-branch.yml
+++ b/.github/workflows/remove-branch.yml
@@ -1,0 +1,56 @@
+name: Remove branch from staging config
+
+on:
+  workflow_dispatch:
+    inputs:
+      file:
+        description: 'Staging config file (e.g. commcare-hq-staging.yml)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch name to remove'
+        required: true
+        type: string
+
+jobs:
+  remove-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Remove branch from config
+        id: remove
+        env:
+          FILE: ${{ inputs.file }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          if [ ! -f "$FILE" ]; then
+            echo "::error::File '$FILE' not found"
+            exit 1
+          fi
+
+          # Remove standalone branch entry (not +-joined conflict resolution branches).
+          # Matches lines like "    - branch-name  # optional comment"
+          # but not "    - foo+branch-name+bar"
+          grep -vP "^\s*-\s+\Q${BRANCH}\E(\s|$)" "$FILE" > "${FILE}.tmp" || true
+          mv "${FILE}.tmp" "$FILE"
+
+          if git diff --quiet -- "$FILE"; then
+            echo "::notice::Branch '$BRANCH' not found in $FILE, nothing to remove"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Removed branch '$BRANCH' from $FILE"
+            git diff -- "$FILE"
+          fi
+
+      - name: Commit and push
+        if: steps.remove.outputs.changed == 'true'
+        env:
+          FILE: ${{ inputs.file }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add "$FILE"
+          git commit -m "Remove merged branch \`$BRANCH\` from $FILE"
+          git push

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ The `autostaging` branch is rebuilt automatically in two ways:
 1. **Config changes:** When `commcare-hq-staging.yml` is pushed to `main` in this repo, a workflow here triggers [`rebuild-staging`](https://github.com/dimagi/commcare-hq/actions/workflows/rebuild-staging.yml) in `dimagi/commcare-hq` via `workflow_dispatch`.
 2. **Branch pushes:** The `rebuild-staging` workflow in `dimagi/commcare-hq` also runs on push to any branch. It checks this config file and skips the rebuild if the pushed branch isn't listed. This means pushes to `master` or to any branch already in the config will trigger a rebuild automatically.
 
+### Auto-removal of merged branches
+
+When a branch in the staging config is merged to `master` in commcare-hq, the `rebuild-staging` workflow detects this and triggers the [`remove-branch`](.github/workflows/remove-branch.yml) workflow in this repo instead of rebuilding. The branch is automatically removed from the config file, and the resulting push to `main` triggers a clean rebuild via trigger 1 above.
+
+This prevents rebuild failures caused by branches that have been deleted after merge. Note that `+`-joined conflict resolution branches (e.g. `foo+bar`) are not automatically removed — see [Resolving Branch Conflicts](#resolving-branch-conflicts) for how to clean those up manually.
+
 The only case where `autostaging` can go stale is when new commits are pushed to a branch declared in a submodule's staging config.
 
 You can monitor triggered runs in the [commcare-hq Actions tab](https://github.com/dimagi/commcare-hq/actions/workflows/rebuild-staging.yml).

--- a/docs/automated-rebuild-trigger.md
+++ b/docs/automated-rebuild-trigger.md
@@ -9,6 +9,10 @@ There are two triggers that keep `autostaging` up to date:
 1. **This repo** — `.github/workflows/trigger-commcare-hq-rebuild.yml` fires on pushes to `main` that modify `commcare-hq-staging.yml`. It triggers `rebuild-staging` in `dimagi/commcare-hq` via `workflow_dispatch`.
 2. **commcare-hq** — The [`rebuild-staging` workflow](https://github.com/dimagi/commcare-hq/blob/master/.github/workflows/rebuild-staging.yml) fires on push to any branch. A `check-branch` job fetches `commcare-hq-staging.yml` and skips the rebuild if the pushed branch isn't listed. This covers pushes to `master` (the base branch) and pushes to branches already in the config. A global concurrency group with `cancel-in-progress: false` ensures at most one rebuild runs at a time, with one queued.
 
+Additionally, merged branches are cleaned up automatically:
+
+3. **Merged branch removal** — When a branch in the staging config is merged to `master` in commcare-hq, the `rebuild-staging` workflow detects the merge commit, checks if the merged branch is in the staging config, and triggers `.github/workflows/remove-branch.yml` in this repo instead of rebuilding. The branch is removed from the config file, and the resulting push to `main` triggers a clean rebuild via trigger 1.
+
 ## How it works
 
 1. GitHub detects a push to `main` that changes `commcare-hq-staging.yml`
@@ -17,16 +21,22 @@ There are two triggers that keep `autostaging` up to date:
 
 ## Authentication
 
-The workflow uses a GitHub App rather than a Personal Access Token (PAT). This gives scoped permissions, short-lived tokens, and no dependency on a personal account.
+The workflows use a GitHub App rather than a Personal Access Token (PAT). This gives scoped permissions, short-lived tokens, and no dependency on a personal account.
 
 **GitHub App:** Staging Branches Automations
 - Configured in the [dimagi org's GitHub Apps settings](https://github.com/organizations/dimagi/settings/apps)
-- Installed only on `dimagi/commcare-hq`
+- Installed on `dimagi/commcare-hq` and `dimagi/staging-branches`
 - Permission: Actions: Read & Write (only)
 
 **Repo secrets** on `dimagi/staging-branches` (managed at [Settings > Secrets](https://github.com/dimagi/staging-branches/settings/secrets/actions)):
 - `STAGING_BRANCHES_APP_ID` — the app's numeric ID (found on the app's General page)
 - `STAGING_BRANCHES_APP_PRIVATE_KEY` — the app's private key in PEM format
+
+**Repo secrets** on `dimagi/commcare-hq` (managed at [Settings > Secrets](https://github.com/dimagi/commcare-hq/settings/secrets/actions)):
+- `STAGING_BRANCHES_APP_ID` — same app ID as above
+- `STAGING_BRANCHES_APP_PRIVATE_KEY` — same private key as above
+
+The commcare-hq secrets are used by the `rebuild-staging` workflow to trigger the `remove-branch` workflow in this repo when a staging branch is merged to master.
 
 ### Rotating credentials
 
@@ -34,6 +44,27 @@ The workflow uses a GitHub App rather than a Personal Access Token (PAT). This g
 2. Under **Private keys**, click **Generate a private key**
 3. Update the `STAGING_BRANCHES_APP_PRIVATE_KEY` secret with the new key's contents
 4. Revoke the old key from the same page
+
+## Merged branch removal
+
+`.github/workflows/remove-branch.yml` is a `workflow_dispatch` workflow that removes a branch entry from a staging config file. It accepts two inputs:
+
+- `file` — the config file name (e.g. `commcare-hq-staging.yml`)
+- `branch` — the branch name to remove
+
+The workflow removes only standalone branch entries (e.g. `- branch-name  # comment`), not `+`-joined conflict resolution branches (e.g. `- foo+branch-name+bar`). If the branch is not found, it exits cleanly with no commit.
+
+### How it's triggered
+
+When a PR is merged to `master` in commcare-hq, the `rebuild-staging` workflow:
+1. Parses the merge commit message to extract the branch name
+2. Checks if the branch is a standalone entry in `commcare-hq-staging.yml`
+3. If found, triggers `remove-branch.yml` in this repo instead of rebuilding
+4. The removal commits to `main`, which triggers `trigger-commcare-hq-rebuild.yml` for a clean rebuild
+
+### Manual use
+
+The workflow can also be triggered manually from the [Actions tab](https://github.com/dimagi/staging-branches/actions/workflows/remove-branch.yml) to remove a branch without editing the file by hand.
 
 ## Adding triggers for other repos
 

--- a/docs/automated-rebuild-trigger.md
+++ b/docs/automated-rebuild-trigger.md
@@ -42,7 +42,9 @@ The commcare-hq secrets are used by the `rebuild-staging` workflow to trigger th
 
 1. Go to the app's settings page in the dimagi org
 2. Under **Private keys**, click **Generate a private key**
-3. Update the `STAGING_BRANCHES_APP_PRIVATE_KEY` secret with the new key's contents
+3. Update the `STAGING_BRANCHES_APP_PRIVATE_KEY` secret in both repos:
+   - [dimagi/staging-branches](https://github.com/dimagi/staging-branches/settings/secrets/actions)
+   - [dimagi/commcare-hq](https://github.com/dimagi/commcare-hq/settings/secrets/actions)
 4. Revoke the old key from the same page
 
 ## Merged branch removal


### PR DESCRIPTION
## Summary

When a branch on staging is merged to master in commcare-hq, the next rebuild
fails because the deleted branch no longer exists. This adds a `remove-branch.yml`
workflow that can be triggered to automatically remove a branch entry from a
staging config file, commit, and push — which then triggers a clean rebuild
via the existing `trigger-commcare-hq-rebuild.yml` pipeline.

Also updates README and docs to cover the new workflow, cross-repo auth setup,
and how merged branch cleanup integrates with the existing rebuild pipeline.

**Companion PR:** dimagi/commcare-hq#37598 (must be merged after this one)

[SAAS-19618](https://dimagi.atlassian.net/browse/SAAS-19618)

🤖 Generated with [Claude Code](https://claude.com/claude-code)