### PR TITLE
Add `reason` input to remove-branch workflow

### DIFF
--- a/.github/workflows/add-branch.yml
+++ b/.github/workflows/add-branch.yml
@@ -29,6 +29,8 @@ jobs:
       ACTOR: ${{ github.actor }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: main
       - uses: astral-sh/setup-uv@v6
 
       - name: Add branch to config

--- a/.github/workflows/remove-branch.yml
+++ b/.github/workflows/remove-branch.yml
@@ -33,6 +33,8 @@ jobs:
       REASON: ${{ inputs.reason }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: main
       - uses: astral-sh/setup-uv@v6
 
       - name: Remove branch from config

--- a/.github/workflows/remove-branch.yml
+++ b/.github/workflows/remove-branch.yml
@@ -11,6 +11,15 @@ on:
         description: 'Branch name to remove'
         required: true
         type: string
+      reason:
+        description: 'Reason for removal'
+        required: false
+        type: choice
+        default: unspecified
+        options:
+          - unspecified
+          - merge
+          - conflict
 
 jobs:
   remove-branch:
@@ -21,6 +30,7 @@ jobs:
     env:
       FILE: ${{ inputs.file }}
       BRANCH: ${{ inputs.branch }}
+      REASON: ${{ inputs.reason }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
@@ -40,7 +50,12 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           git add "$FILE"
-          git commit -m "Remove merged branch \`$BRANCH\` from $FILE"
+          case "$REASON" in
+            merge) MSG="Remove merged branch \`$BRANCH\` from $FILE" ;;
+            conflict) MSG="Remove conflicting branch \`$BRANCH\` from $FILE" ;;
+            *) MSG="Remove branch \`$BRANCH\` from $FILE" ;;
+          esac
+          git commit -m "$MSG"
           git push
           echo "changed=true" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Adds a `reason` choice input (`unspecified` default, `merge`, `conflict`) to `.github/workflows/remove-branch.yml`. Commit message now varies by reason: `Remove merged branch ...`, `Remove conflicting branch ...`, or plain `Remove branch ...`.
- To facilitate testing the above, pins `actions/checkout` to `ref: main` in both `add-branch.yml` and `remove-branch.yml` so a `workflow_dispatch` from a non-default branch (e.g. when testing) still commits to the canonical staging config on `main`.

Paired with https://github.com/dimagi/commcare-hq/pull/37661, which updates commcare-hq's `rebuild-staging.yml` to pass `reason=merge` when it auto-triggers this workflow on a merge to master. The two PRs are intended to be merged together.

## Test plan
- [x] Trigger the workflow with `reason` `conflict` and confirm the resulting commit message
- [x] Trigger the workflow with `reason` `merge` and confirm the resulting commit message
- [x] Trigger the workflow with no `reason` given and confirm the resulting commit message

In the course of the above, I will also incedentally test the fix I added to this PR specifically to facilitate testing: triggering a non-`main` ref and confirm the resulting commit lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)