### PR TITLE
Stop GHA from breaking staging YAMLs on long branch lines

### DIFF
--- a/scripts/edit_branches.py
+++ b/scripts/edit_branches.py
@@ -58,6 +58,7 @@ def load(path):
     """Open the YAML, matching ruamel's output indent to the file's existing style."""
     yaml = YAML()
     yaml.preserve_quotes = True
+    yaml.width = 4096  # don't wrap long branch+comment lines
     data = yaml.load(Path(path))
     indent = data["branches"].lc.col
     yaml.indent(mapping=indent, sequence=indent, offset=indent)


### PR DESCRIPTION
## Technical Summary

`scripts/edit_branches.py` (used by the `add-branch` and `remove-branch` GHA workflows) loads and re-dumps the staging YAMLs with `ruamel.yaml`, which defaults to `width=80`. When a `- branch  # comment` entry exceeds 80 chars, ruamel folds it across two lines — leaving the file in an invalid state that breaks the next build.

This was flagged by Jing after `af8345d` re-corrupted the file Martin had manually fixed in `95d6200`. Both incidents involved the same long `ay/add-open-close-filter-kyc-payments+dmr/gettext_lazy+ay/payments-lookup-table-filters` entry in `commcare-hq-staging.yml`.

Fix: set `yaml.width = 4096` on the loader so long entries stay on one line. The currently-broken line in `commcare-hq-staging.yml` is not touched here — it will need a separate manual cleanup as before, but won't recur after this PR.

## Safety Assurance

### Safety story

- Reproduced the bug locally by loading the current `commcare-hq-staging.yml` and triggering a `remove` — confirmed ruamel folds the long line as observed in production.
- Applied the same operation with `yaml.width = 4096` — confirmed the entry stays on a single line.
- Change is scoped to a single line in a small utility script; no behavior change for any entry under 4096 chars.

### Automated test coverage

None — this repo doesn't have tests for `edit_branches.py`. The next `add-branch` / `remove-branch` workflow run will exercise the change end-to-end.
